### PR TITLE
Constant fields do not require an underscore.

### DIFF
--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/NamingFieldPascalUnderscoreTests.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/NamingFieldPascalUnderscoreTests.cs
@@ -264,6 +264,26 @@ namespace IntelliTectAnalyzer.Tests
             VerifyCSharpDiagnostic(test);
         }
 
+        [TestMethod]
+        [Description("Issue 11")]
+        public void ConstantField_DoesNotPromptWarning()
+        {
+            var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+        public const int Foo = 42;
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new CodeFixes.NamingFieldPascalUnderscore();

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace IntelliTectAnalyzer.Analyzers
@@ -37,6 +38,11 @@ namespace IntelliTectAnalyzer.Analyzers
 
             if (namedTypeSymbol.Name.StartsWith("_") && namedTypeSymbol.Name.Length > 1 
                                                      && char.IsUpper(namedTypeSymbol.Name.Skip(1).First()))
+            {
+                return;
+            }
+
+            if (namedTypeSymbol is IFieldSymbol field && field.IsConst)
             {
                 return;
             }


### PR DESCRIPTION
Fixes #11 

There is some worthwhile discussion on whether this is actually correct.