### PR TITLE
Add FxCopAnalyzers as dependency

### DIFF
--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticResult.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticResult.cs
@@ -35,24 +35,28 @@ namespace TestHelper
     /// </summary>
     public struct DiagnosticResult
     {
-        private DiagnosticResultLocation[] locations;
-
+        private DiagnosticResultLocation[] _Locations;
+        
+#pragma warning disable CA1819 // Properties should not return arrays
+        
         public DiagnosticResultLocation[] Locations
         {
             get
             {
-                if (locations == null)
+                if (_Locations == null)
                 {
-                    locations = new DiagnosticResultLocation[] { };
+                    _Locations = Array.Empty<DiagnosticResultLocation>();
                 }
-                return locations;
+                return _Locations;
             }
 
             set
             {
-                locations = value;
+                _Locations = value;
             }
         }
+        
+#pragma warning restore CA1819 // Properties should not return arrays
 
         public DiagnosticSeverity Severity { get; set; }
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -151,13 +151,18 @@ namespace TestHelper
 
             var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
 
-            Solution solution = new AdhocWorkspace()
-                .CurrentSolution
-                .AddProject(projectId, TestProjectName, TestProjectName, language)
-                .AddMetadataReference(projectId, _CorlibReference)
-                .AddMetadataReference(projectId, _SystemCoreReference)
-                .AddMetadataReference(projectId, _CSharpSymbolsReference)
-                .AddMetadataReference(projectId, _CodeAnalysisReference);
+            Solution solution;
+
+            using (var adHockWorkspace = new AdhocWorkspace())
+            {
+                solution = adHockWorkspace
+                    .CurrentSolution
+                    .AddProject(projectId, TestProjectName, TestProjectName, language)
+                    .AddMetadataReference(projectId, _CorlibReference)
+                    .AddMetadataReference(projectId, _SystemCoreReference)
+                    .AddMetadataReference(projectId, _CSharpSymbolsReference)
+                    .AddMetadataReference(projectId, _CodeAnalysisReference);
+            }
 
             int count = 0;
             foreach (var source in sources)

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -15,10 +15,10 @@ namespace TestHelper
     /// </summary>
     public abstract partial class DiagnosticVerifier
     {
-        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
-        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
-        private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
-        private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+        private static readonly MetadataReference _CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        private static readonly MetadataReference _SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference _CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+        private static readonly MetadataReference _CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
 
         internal static string DefaultFilePathPrefix = "Test";
         internal static string CSharpDefaultFileExt = "cs";
@@ -48,6 +48,11 @@ namespace TestHelper
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
         protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
         {
+            if (documents is null)
+            {
+                throw new ArgumentNullException(nameof(documents));
+            }
+            
             var projects = new HashSet<Project>();
             foreach (var document in documents)
             {
@@ -146,13 +151,13 @@ namespace TestHelper
 
             var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
 
-            var solution = new AdhocWorkspace()
+            Solution solution = new AdhocWorkspace()
                 .CurrentSolution
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
-                .AddMetadataReference(projectId, CorlibReference)
-                .AddMetadataReference(projectId, SystemCoreReference)
-                .AddMetadataReference(projectId, CSharpSymbolsReference)
-                .AddMetadataReference(projectId, CodeAnalysisReference);
+                .AddMetadataReference(projectId, _CorlibReference)
+                .AddMetadataReference(projectId, _SystemCoreReference)
+                .AddMetadataReference(projectId, _CSharpSymbolsReference)
+                .AddMetadataReference(projectId, _CodeAnalysisReference);
 
             int count = 0;
             foreach (var source in sources)
@@ -162,6 +167,7 @@ namespace TestHelper
                 solution = solution.AddDocument(documentId, newFileName, SourceText.From(source));
                 count++;
             }
+
             return solution.GetProject(projectId);
         }
         #endregion

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/IntelliTectAnalyzer.Tests.csproj
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/IntelliTectAnalyzer.Tests.csproj
@@ -5,11 +5,13 @@
     <RuntimeFrameworkVersion>2.2.1</RuntimeFrameworkVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <LangVersion>7.3</LangVersion>
+    <NoWarn>CA2007,CA1815,CA1303,CA1707,CA1305</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Verifiers/CodeFixVerifier.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Verifiers/CodeFixVerifier.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -72,7 +73,7 @@ namespace TestHelper
         /// <param name="newSource">A class in the form of a string after the CodeFix was applied to it</param>
         /// <param name="codeFixIndex">Index determining which codefix to apply if there are multiple</param>
         /// <param name="allowNewCompilerDiagnostics">A bool controlling whether or not the test will fail if the CodeFix introduces other warnings after being applied</param>
-        private async Task VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
+        private static async Task VerifyFix(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics)
         {
             var document = CreateDocument(oldSource, language);
             var analyzerDiagnostics = GetSortedDiagnosticsFromDocuments(analyzer, new[] { document });

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Verifiers/DiagnosticVerifier.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -85,7 +86,7 @@ namespace TestHelper
         /// <param name="language">The language of the classes represented by the source strings</param>
         /// <param name="analyzer">The analyzer to be run on the source code</param>
         /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the sources</param>
-        private void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
+        private static void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
         {
             var diagnostics = GetSortedDiagnostics(sources, language, analyzer);
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
@@ -103,7 +104,7 @@ namespace TestHelper
         /// <param name="expectedResults">Diagnostic Results that should have appeared in the code</param>
         private static void VerifyDiagnosticResults(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expectedResults)
         {
-            int expectedCount = expectedResults.Count();
+            int expectedCount = expectedResults.Length;
             int actualCount = actualResults.Count();
 
             if (expectedCount != actualCount)
@@ -181,7 +182,9 @@ namespace TestHelper
         {
             var actualSpan = actual.GetLineSpan();
 
-            Assert.IsTrue(actualSpan.Path == expected.Path || (actualSpan.Path != null && actualSpan.Path.Contains("Test0.") && expected.Path.Contains("Test.")),
+            Assert.IsTrue(actualSpan.Path == expected.Path || (actualSpan.Path != null 
+                                                               && actualSpan.Path.Contains("Test0.", StringComparison.Ordinal) 
+                                                               && expected.Path.Contains("Test.", StringComparison.Ordinal)),
                 string.Format("Expected diagnostic to be in file \"{0}\" was actually in file \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
                     expected.Path, actualSpan.Path, FormatDiagnostics(analyzer, diagnostic)));
 
@@ -242,7 +245,7 @@ namespace TestHelper
                             Assert.IsTrue(location.IsInSource,
                                 $"Test base does not currently handle diagnostics in metadata locations. Diagnostic in metadata: {diagnostics[i]}\r\n");
 
-                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs") ? "GetCSharpResultAt" : "GetBasicResultAt";
+                            string resultMethodName = diagnostics[i].Location.SourceTree.FilePath.EndsWith(".cs", StringComparison.Ordinal) ? "GetCSharpResultAt" : "GetBasicResultAt";
                             var linePosition = diagnostics[i].Location.GetLineSpan().StartLinePosition;
 
                             builder.AppendFormat("{0}({1}, {2}, {3}.{4})",

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Vsix/IntelliTectAnalyzer.Vsix.csproj
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Vsix/IntelliTectAnalyzer.Vsix.csproj
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.6\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.6\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -51,6 +56,7 @@
     <StartArguments>/rootsuffix Roslyn</StartArguments>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -61,6 +67,27 @@
       <Name>IntelliTectAnalyzer</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\analyzers\dotnet\cs\Microsoft.CodeAnalysis.VersionCheckAnalyzer.resources.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.2.9.6\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeQuality.Analyzers.2.9.6\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NetCore.Analyzers.2.9.6\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.NetFramework.Analyzers.2.9.6\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.6\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.6\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
 </Project>

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Vsix/packages.config
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Vsix/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="2.9.6" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="2.9.6" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="2.9.6" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.NetCore.Analyzers" version="2.9.6" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.NetFramework.Analyzers" version="2.9.6" targetFramework="net461" developmentDependency="true" />
+</packages>

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -9,20 +11,25 @@ namespace IntelliTectAnalyzer.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NamingFieldPascalUnderscore : DiagnosticAnalyzer
     {
-        public const string _DiagnosticId = "INTL0001";
-        private const string _Title = "Fields _PascalCase";
-        private const string _MessageFormat = "Fields should be named _PascalCase";
-        private const string _Description = "All fields should be in the format _PascalCase";
-        private const string _Category = "Naming";
-        private const string _HelpLinkUri = "https://github.com/IntelliTect/CodingStandards";
+        public const string DiagnosticId = "INTL0001";
+        private const string Title = "Fields _PascalCase";
+        private const string MessageFormat = "Fields should be named _PascalCase";
+        private const string Description = "All fields should be in the format _PascalCase";
+        private const string Category = "Naming";
+        private const string HelpLinkUri = "https://github.com/IntelliTect/CodingStandards";
 
-        private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(_DiagnosticId, _Title, _MessageFormat, 
-            _Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _Description, _HelpLinkUri);
+        private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 
         public override void Initialize(AnalysisContext context)
         {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Field);
         }
@@ -44,7 +51,7 @@ namespace IntelliTectAnalyzer.Analyzers
                 return;
             }
 
-            if (namedTypeSymbol.Name.StartsWith("_") && namedTypeSymbol.Name.Length > 1 
+            if (namedTypeSymbol.Name.StartsWith("_", StringComparison.Ordinal) && namedTypeSymbol.Name.Length > 1 
                                                      && char.IsUpper(namedTypeSymbol.Name.Skip(1).First()))
             {
                 return;

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingPropertyPascal.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingPropertyPascal.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -8,20 +9,25 @@ namespace IntelliTectAnalyzer.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NamingPropertyPascal : DiagnosticAnalyzer
     {
-        public const string _DiagnosticId = "INTL0002";
-        private const string _Title = "Properties PascalCase";
-        private const string _MessageFormat = "Properties should be PascalCase";
-        private const string _Description = "All properties should be in the format PascalCase";
-        private const string _Category = "Naming";
-        private const string _HelpLinkUri = "https://github.com/IntelliTect/CodingStandards";
+        public const string DiagnosticId = "INTL0002";
+        private const string Title = "Properties PascalCase";
+        private const string MessageFormat = "Properties should be PascalCase";
+        private const string Description = "All properties should be in the format PascalCase";
+        private const string Category = "Naming";
+        private const string HelpLinkUri = "https://github.com/IntelliTect/CodingStandards";
 
-        private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(_DiagnosticId, _Title, _MessageFormat, 
-            _Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _Description,_HelpLinkUri);
+        private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description,HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 
         public override void Initialize(AnalysisContext context)
         {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Property);
         }
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/AssemblyInfo.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Resources;
+
+[assembly: NeutralResourcesLanguage("en")]

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingFieldPascalUnderscore.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingFieldPascalUnderscore.cs
@@ -19,9 +19,9 @@ namespace IntelliTectAnalyzer.CodeFixes
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingFieldPascalUnderscore)), Shared]
     public class NamingFieldPascalUnderscore : CodeFixProvider
     {
-        private const string _Title = "Fix Naming Violation: Follow _PascalCase";
+        private const string Title = "Fix Naming Violation: Follow _PascalCase";
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Analyzers.NamingFieldPascalUnderscore._DiagnosticId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Analyzers.NamingFieldPascalUnderscore.DiagnosticId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {
@@ -41,9 +41,9 @@ namespace IntelliTectAnalyzer.CodeFixes
             // Register a code action that will invoke the fix.
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: _Title,
+                    title: Title,
                     createChangedSolution: c => MakePascalWithUnderscore(context.Document, declaration, c),
-                    equivalenceKey: _Title),
+                    equivalenceKey: Title),
                 diagnostic);
         }
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingPropertyPascal.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingPropertyPascal.cs
@@ -19,9 +19,9 @@ namespace IntelliTectAnalyzer.CodeFixes
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingPropertyPascal)), Shared]
     public class NamingPropertyPascal : CodeFixProvider
     {
-        private const string _Title = "Fix Naming Violation: Follow PascalCase";
+        private const string Title = "Fix Naming Violation: Follow PascalCase";
 
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Analyzers.NamingPropertyPascal._DiagnosticId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(Analyzers.NamingPropertyPascal.DiagnosticId);
 
         public sealed override FixAllProvider GetFixAllProvider()
         {
@@ -41,9 +41,9 @@ namespace IntelliTectAnalyzer.CodeFixes
             // Register a code action that will invoke the fix.
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    title: _Title,
+                    title: Title,
                     createChangedSolution: c => MakePascal(context.Document, declaration, c),
-                    equivalenceKey: _Title),
+                    equivalenceKey: Title),
                 diagnostic);
         }
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/IntelliTectAnalyzer.csproj
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/IntelliTectAnalyzer.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Warnings suppressed in Solution

CA2007 - Consider calling ConfigureAwait on the awaited task
CA1815 - DiagnosticResult should override Equals, ==, !=
CA1303 - Retrieve strings from Resource Table
CA1707 - Remove underscores
CA1305 - string.Format could vary based on user locale. Use IFormatProvider