### PR TITLE
flag attribute if anything is on the same line

### DIFF
--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/AttributesOnSeparateLinesTests.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/AttributesOnSeparateLinesTests.cs
@@ -118,7 +118,97 @@ int Prop {get;set;}
             VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(19, 13));
         }
 
-  
+        [TestMethod]
+        public void MethodAttributeLineViolation_AttributeOnSameLineAsMethodSignature_Warning()
+        {
+            var test = @"using System;
+
+namespace ConsoleApp
+{
+    class AAttribute : Attribute
+    {
+    }
+
+    class Program
+    {
+        [A]static void Main()
+        {
+        }
+    }
+}";
+            VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(11, 10));
+        }
+
+        [TestMethod]
+        public void ClassAttributeLineViolation_AttributeOnSameLineAsClassName_Warning()
+        {
+            var test = @"using System;
+
+namespace ConsoleApp
+{
+    class AAttribute : Attribute
+    {
+    }
+
+    [A]class Program
+    {
+        static void Main()
+        {
+        }
+    }
+}";
+            VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(9, 6));
+        }
+
+        [TestMethod]
+        public void PropertyAttributeLineViolation_AttributeOnSameLineAsProperty_Warning()
+        {
+            var test = @"using System;
+
+namespace ConsoleApp
+{
+    class AAttribute : Attribute
+    {
+    }
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+
+        [A]int Prop {get;set;}
+    }
+}";
+            VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(15, 10));
+        }
+
+        [TestMethod]
+        public void PropertyAttributeLineViolation_AttributeOnSameLineAsEnum_Warning()
+        {
+            var test = @"using System;
+
+namespace ConsoleApp
+{
+    class AAttribute : Attribute
+    {
+    }
+
+    public enum Foo
+    {
+        [A]Bar
+    }
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+}";
+            VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(11, 10));
+        }
+
         [TestMethod]
         public async Task ClassAttributeLineViolation_CodeFix_TwoAttributesOnSameLine_TwoArgumentsOnSeparateLines()
         {

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
@@ -38,7 +38,7 @@ namespace IntelliTectAnalyzer.Analyzers
             if (namedTypeSymbol.GetAttributes().Any())
             {
                 IDictionary<int, AttributeData> lineDict = new Dictionary<int, AttributeData>();
-                lineDict.Add(namedTypeSymbol.Locations[0].GetLineSpan().StartLinePosition.Line, null);
+                int symbolLineNo = namedTypeSymbol.Locations[0].GetLineSpan().StartLinePosition.Line;
                 foreach (AttributeData attribute in namedTypeSymbol.GetAttributes())
                 {
                     SyntaxReference applicationSyntaxReference = attribute.ApplicationSyntaxReference;
@@ -46,8 +46,8 @@ namespace IntelliTectAnalyzer.Analyzers
                     SyntaxTree syntaxTree = applicationSyntaxReference.SyntaxTree;
                     FileLinePositionSpan linespan = syntaxTree.GetLineSpan(textspan);
 
-                    int lineNo = linespan.StartLinePosition.Line;
-                    if (lineDict.ContainsKey(lineNo))
+                    int attributeLineNo = linespan.StartLinePosition.Line;
+                    if (lineDict.ContainsKey(attributeLineNo) || attributeLineNo == symbolLineNo)
                     {
                         Location location = syntaxTree.GetLocation(textspan);
                         Diagnostic diagnostic = Diagnostic.Create(_Rule, location, attribute.AttributeClass.Name);
@@ -56,7 +56,7 @@ namespace IntelliTectAnalyzer.Analyzers
                     }
                     else
                     {
-                        lineDict.Add(lineNo, attribute);
+                        lineDict.Add(attributeLineNo, attribute);
                     }
                 }
             }

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
@@ -38,6 +38,7 @@ namespace IntelliTectAnalyzer.Analyzers
             if (namedTypeSymbol.GetAttributes().Any())
             {
                 IDictionary<int, AttributeData> lineDict = new Dictionary<int, AttributeData>();
+                lineDict.Add(namedTypeSymbol.Locations[0].GetLineSpan().StartLinePosition.Line, null);
                 foreach (AttributeData attribute in namedTypeSymbol.GetAttributes())
                 {
                     SyntaxReference applicationSyntaxReference = attribute.ApplicationSyntaxReference;


### PR DESCRIPTION
This is at least a start at fixing #36.

I added 4 unit tests to show it works on a class, method, property, or enum.