### PR TITLE
Fix67

### DIFF
--- a/docs/.vscode/settings.json
+++ b/docs/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
     "cSpell.words": [
         "Fezzik",
+        "IntelliTect",
         "MVVM",
         "arity",
+        "editorconfig",
         "finalizers",
         "hardcode",
         "serializable",

--- a/docs/analyzers/00XX.Naming.md
+++ b/docs/analyzers/00XX.Naming.md
@@ -1,0 +1,45 @@
+# OOXX Block - Naming
+
+## INTL0001 
+### Fields _PascalCase
+
+Fields should be specified in _PascalCase. *Always* with a leading underscore, regardless
+of visibility modifier.
+
+**Allowed**
+```c#
+class SomeClass
+{
+    public string _MyField;
+}
+```
+**Disallowed**
+```c#
+class SomeClass
+{
+    public string _myField;
+    public string myField;
+}
+```
+
+## INTL0002
+### Properties PascalCase
+
+Fields should be PascalCase
+
+**Allowed**
+```c#
+class SomeClass
+{
+    public string MyProperty { get; set; }
+}
+```
+
+**Disallowed**
+```c#
+class SomeClass
+{
+    public string myProperty { get; set; }
+    public string _MyProperty { get; set; }
+}
+```

--- a/docs/analyzers/01XX.Formatting.md
+++ b/docs/analyzers/01XX.Formatting.md
@@ -1,0 +1,28 @@
+# O1XX Block - Formatting
+
+## INTL0101
+### Attributes on separate lines
+
+All attributes should be on separate lines and be wrapped in their own braces.
+
+**Allowed**
+```c#
+[FooClass]
+[BarClass]
+class SomeClass
+{
+    [Foo]
+    [Bar]
+    public string MyProperty { get; set; }
+}
+```
+
+**Disallowed**
+```c#
+[FooClass, BarClass]
+class SomeClass
+{
+    [Foo][Bar]
+    public string MyProperty { get; set; }
+}
+```

--- a/docs/analyzers/02XX.Reliability.md
+++ b/docs/analyzers/02XX.Reliability.md
@@ -1,0 +1,30 @@
+# O2XX Block - Reliability
+
+## INTL0201
+### Async Void
+
+Async methods must return either `Task` or `Task<T>`. 
+
+**Allowed**
+```c#
+public async void SomeTopLevelMethod(object sender, EventArgs e)
+{
+    // some code
+}
+
+public async Task SomeMethod()
+{
+    // some code
+}
+```
+**Disallowed**
+```c#
+public async void SomeMethod()
+{
+    // some code
+}
+```
+
+### When to suppress
+
+The only acceptable use of `async void` is in a top level methods, such as event handlers. For these cases it is safe to suppress this warning. In all other cases, this warning should **NOT** be suppressed.

--- a/docs/analyzers/03XX.Performance.md
+++ b/docs/analyzers/03XX.Performance.md
@@ -1,0 +1,33 @@
+# O3XX Block - Formatting
+
+## INTL0301
+### Favor using the method `EnumerateFiles` over the `GetFiles` method.
+
+When using the `System.IO.Directory` class, it is suggested to use the `EnumerateFiles` static method
+instead of the `GetFiles` method.  In the remarks section of the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratefiles), it is stated that using the `EnumerateFiles` method is more efficient because you can start enumerating the collection before all the results are returned:
+
+ > The EnumerateFiles and GetFiles methods differ as follows: When you use EnumerateFiles, you can start enumerating the       
+ > collection of names before the whole collection is returned; when you use GetFiles, you must wait for the whole array of 
+ > names to be returned before you can access the array. Therefore, when you are working with many files and directories, 
+ > EnumerateFiles can be more efficient.
+ > The returned collection is not cached; each call to the GetEnumerator on the collection will start a new enumeration.
+
+### When to suppress
+
+Do not suppress a warning from this rule.
+
+## INTL0302
+### Favor using the method `EnumerateDirectories` over the `GetDirectories` method.
+
+When using the `System.IO.Directory` class, it is suggested to use the `EnumerateDirectories` static method
+instead of the `GetDirectories` method.  In the remarks section of the [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.enumeratedirectories), it is stated that using the `EnumerateDirectories ` method is more efficient because you can start enumerating the collection before all the results are returned:
+
+ > The EnumerateDirectories and GetDirectories methods differ as follows: When you use EnumerateDirectories, you can start 
+ > enumerating the collection of names before the whole collection is returned; when you use GetDirectories, you must wait 
+ > for the whole array of names to be returned before you can access the array. Therefore, when you are working with many 
+ > files and directories, EnumerateDirectories can be more efficient.
+ > The returned collection is not cached; each call to the GetEnumerator on the collection will start a new enumeration.
+
+### When to suppress
+
+Do not suppress a warning from this rule.

--- a/docs/analyzers/index.md
+++ b/docs/analyzers/index.md
@@ -1,0 +1,13 @@
+## Naming INTL00XX 
+- [INTL0001 Fields _PascalCase]({{ site.baseurl }}{% link analyzers/00XX.Naming.md %}#intl0001)
+- [INTL0002 Properties PascalCase]({{ site.baseurl }}{% link analyzers/00XX.Naming.md %}#intl0002)
+
+## Formatting INTL01XX
+- [INTL0101 Attributes on separate lines]({{ site.baseurl }}{% link analyzers/01XX.Formatting.md %}#intl0101)
+
+## Reliability INTL02XX
+- [INTL0201 Async Void]({{ site.baseurl }}{% link analyzers/02XX.Reliability.md %}#intl0201)
+
+## Performance INTL03XX
+- [INTL0301 Favor EnumerateFiles]({{ site.baseurl }}{% link analyzers/03XX.Performance.md %}#intl0301)
+- [INTL0302 Favor EnumerateDirectories]({{ site.baseurl }}{% link analyzers/03XX.Performance.md %}#intl0302)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,3 +13,12 @@ Design Standards
 * [External Libraries]({{ site.baseurl }}{% link external_libraries/index.md %})
 * [APIs]({{ site.baseurl }}{% link apis/index.md %})
 * [Security]({{ site.baseurl }}{% link security/index.md %})
+
+Analyzers
+=========
+- [All Analyzers]({{ site.baseurl }}{% link analyzers/index.md %})
+
+- [Naming: INTL00XX]({{ site.baseurl }}{% link analyzers/00XX.Naming.md %})
+- [Formatting: INTL01XX]({{ site.baseurl }}{% link analyzers/01XX.Formatting.md %})
+- [Reliability: INTL02XX]({{ site.baseurl }}{% link analyzers/02XX.Reliability.md %})
+- [Performance: INTL03XX]({{ site.baseurl }}{% link analyzers/03XX.Performance.md %})


### PR DESCRIPTION
Moving wiki contents to git hub pages.

Fixes #67

Dependent on:
https://github.com/IntelliTect/CodingStandards/pull/72
https://github.com/IntelliTect/CodingStandards/pull/73