### PR TITLE
Adding integration tests that run the analyzer on itself.

### DIFF
--- a/IntelliTectAnalyzer.sln
+++ b/IntelliTectAnalyzer.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelliTectAnalyzer.Integration.Tests", "IntelliTectAnalyzer\IntelliTectAnalyzer.Integration.Tests\IntelliTectAnalyzer.Integration.Tests.csproj", "{25B557AC-D6C9-4719-A977-3DC1666C5347}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{2B4BFC2E-4BD4-4651-A0F4-E926EF246ADE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B4BFC2E-4BD4-4651-A0F4-E926EF246ADE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B4BFC2E-4BD4-4651-A0F4-E926EF246ADE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25B557AC-D6C9-4719-A977-3DC1666C5347}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25B557AC-D6C9-4719-A977-3DC1666C5347}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25B557AC-D6C9-4719-A977-3DC1666C5347}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25B557AC-D6C9-4719-A977-3DC1666C5347}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/AnalyzerTests.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/AnalyzerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IntelliTectAnalyzer.Integration.Tests
+{
+    [TestClass]
+    public class AnalyzerTests
+    {
+        static AnalyzerTests()
+        {
+            MSBuildLocatorInitializer.Initialize();
+        }
+
+        [TestMethod]
+        public async Task RunOnSelf()
+        {
+            await ProcessProject(new FileInfo(Path.Combine("..", "..", "..", "..", "IntelliTectAnalyzer","IntelliTectAnalyzer.csproj")))
+                .ConfigureAwait(false);
+        }
+
+        public static async Task ProcessProject(FileInfo projectFile)
+        {
+            if (projectFile is null)
+            {
+                throw new ArgumentNullException(nameof(projectFile));
+            }
+
+            using var workspace = MSBuildWorkspace.Create();
+            Project project = await workspace.OpenProjectAsync(projectFile.FullName).ConfigureAwait(false);
+
+            CompilationWithAnalyzers compilationWithAnalyzers = (await project.GetCompilationAsync().ConfigureAwait(false))
+                .WithAnalyzers(ImmutableArray.Create(GetAnalyzers().ToArray()));
+
+            ImmutableArray<Diagnostic> diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+            foreach (Diagnostic diag in diags)
+            {
+                Assert.Fail(diag.ToString());
+            }
+        }
+
+        private static IEnumerable<DiagnosticAnalyzer> GetAnalyzers()
+        {
+            Assembly assembly = typeof(AnalyzerBlock).Assembly;
+            foreach (Type analyzer in assembly.GetTypes().Where(x => typeof(DiagnosticAnalyzer).IsAssignableFrom(x)))
+            {
+                if (analyzer.IsAbstract) continue;
+
+                if (Activator.CreateInstance(analyzer) is DiagnosticAnalyzer analyzerInstance)
+                {
+                    yield return analyzerInstance;
+                }
+            }
+        }
+
+    }
+}

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/IntelliTectAnalyzer.Integration.Tests.csproj
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/IntelliTectAnalyzer.Integration.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0-beta1-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0-beta1-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0-beta1-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0-beta1-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IntelliTectAnalyzer\IntelliTectAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/MSBuildLocatorInitializer.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Integration.Tests/MSBuildLocatorInitializer.cs
@@ -1,0 +1,16 @@
+﻿namespace IntelliTectAnalyzer.Integration.Tests
+{
+    internal static class MSBuildLocatorInitializer
+    {
+        static MSBuildLocatorInitializer()
+        {
+            VisualStudioInstance =
+                Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults();
+        }
+        public static void Initialize()
+        {
+        }
+        public static Microsoft.Build.Locator.VisualStudioInstance VisualStudioInstance { get; }
+
+    }
+}

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/NamingMethodPascalTests.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/NamingMethodPascalTests.cs
@@ -79,6 +79,29 @@ namespace IntelliTectAnalyzer.Tests
         }
 
         [TestMethod]
+        public void AutoProperty_PascalCasedMethod_NoDiagnosticInformationReturned()
+        {
+            string test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {   
+            public int Number { get; set; }
+        }
+    }";
+
+            VerifyCSharpDiagnostic(test);
+        }
+
+
+        [TestMethod]
         [Description("Issue 70")]
         public void MethodNotPascalCase_InNativeMethodsClass_NoDiagnosticInformationReturned()
         {

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/UnusedLocalVariableTests.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer.Test/UnusedLocalVariableTests.cs
@@ -1,7 +1,5 @@
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestHelper;

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AsyncVoid.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AsyncVoid.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -14,11 +13,11 @@ namespace IntelliTectAnalyzer.Analyzers
         private const string MessageFormat = "Async methods should not return void.";
         private const string Description = "Async methods must return either Task or Task<T>.";
         private const string Category = "Reliability";
-        private static readonly string HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Reliability, 
+        private static readonly string _HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Reliability,
             DiagnosticId);
 
         private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
-            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, HelpLinkUri);
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, _HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/AttributesOnSeparateLines.cs
@@ -14,11 +14,11 @@ namespace IntelliTectAnalyzer.Analyzers
         private const string MessageFormat = "Attributes should be on separate lines";
         private const string Description = "All attributes should be on separate lines and be wrapped in their own braces.";
         private const string Category = "Formatting";
-        private static readonly string HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Formatting, 
+        private static readonly string _HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Formatting, 
             DiagnosticId);
 
         private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat,
-            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, HelpLinkUri);
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, _HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/FavorDirectoryEnumerationCalls.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/FavorDirectoryEnumerationCalls.cs
@@ -87,8 +87,10 @@ namespace IntelliTectAnalyzer.Analyzers
             internal const string DiagnosticId = "INTL0301";
             internal const string Title = "Favor using EnumerateFiles";
             internal const string MessageFormat = "Favor using the method `EnumerateFiles` over the `GetFiles` method.";
+#pragma warning disable INTL0001 // Allow field to not be prefixed with an underscore ot match the style
             internal static readonly string HelpMessageUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Performance,
                 DiagnosticId);
+#pragma warning restore INTL0001 
 
             internal const string Description =
                 "When you use EnumerateFiles, you can start enumerating the collection of names before the whole collection is returned; when you use GetFiles, you must wait for the whole array of names to be returned before you can access the array. Therefore, when you are working with many files and directories, EnumerateFiles can be more efficient.";
@@ -99,8 +101,10 @@ namespace IntelliTectAnalyzer.Analyzers
             internal const string DiagnosticId = "INTL0302";
             internal const string Title = "Favor using EnumerateDirectories";
             internal const string MessageFormat = "Favor using the method `EnumerateDirectories` over the `GetDirectories` method.";
+#pragma warning disable INTL0001 // Allow field to not be prefixed with an underscore ot match the style
             internal static readonly string HelpMessageUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Performance,
                 DiagnosticId);
+#pragma warning restore INTL0001 
 
             internal const string Description =
                 "When you use EnumerateDirectories, you can start enumerating the collection of names before the whole collection is returned; when you use GetDirectories, you must wait for the whole array of names to be returned before you can access the array. Therefore, when you are working with many files and directories, EnumerateDirectories can be more efficient.";

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingFieldPascalUnderscore.cs
@@ -14,11 +14,11 @@ namespace IntelliTectAnalyzer.Analyzers
         private const string MessageFormat = "Fields should be named _PascalCase";
         private const string Description = "All fields should be in the format _PascalCase";
         private const string Category = "Naming";
-        private static readonly string HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
+        private static readonly string _HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
             DiagnosticId);
 
         private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
-            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, HelpLinkUri);
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description, _HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingMethodPascal.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingMethodPascal.cs
@@ -17,11 +17,11 @@ namespace IntelliTectAnalyzer.Analyzers
         private const string MessageFormat = "Methods should be PascalCase";
         private const string Description = "All methods should be in the format PascalCase";
         private const string Category = "Naming";
-        private static readonly string HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
+        private static readonly string _HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
             DiagnosticId);
 
         private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
-            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description,HelpLinkUri);
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description,_HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 
@@ -56,8 +56,7 @@ namespace IntelliTectAnalyzer.Analyzers
         {
             ISymbol namedTypeSymbol = context.Symbol;
 
-            ImmutableArray<AttributeData> attributes = namedTypeSymbol.GetAttributes().AddRange(namedTypeSymbol.ContainingType.GetAttributes());
-            if (attributes.Any(attribute => attribute.AttributeClass?.Name == nameof(System.CodeDom.Compiler.GeneratedCodeAttribute)))
+            if (!namedTypeSymbol.CanBeReferencedByName)
             {
                 return;
             }
@@ -68,6 +67,12 @@ namespace IntelliTectAnalyzer.Analyzers
             }
 
             if (char.IsUpper(namedTypeSymbol.Name.First()))
+            {
+                return;
+            }
+
+            ImmutableArray<AttributeData> attributes = namedTypeSymbol.GetAttributes().AddRange(namedTypeSymbol.ContainingType.GetAttributes());
+            if (attributes.Any(attribute => attribute.AttributeClass?.Name == nameof(System.CodeDom.Compiler.GeneratedCodeAttribute)))
             {
                 return;
             }

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingPropertyPascal.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/Analyzers/NamingPropertyPascal.cs
@@ -14,11 +14,11 @@ namespace IntelliTectAnalyzer.Analyzers
         private const string MessageFormat = "Properties should be PascalCase";
         private const string Description = "All properties should be in the format PascalCase";
         private const string Category = "Naming";
-        private static readonly string HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
+        private static readonly string _HelpLinkUri = DiagnosticUrlBuilder.GetUrl(AnalyzerBlock.Naming, 
             DiagnosticId);
 
         private static readonly DiagnosticDescriptor _Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, 
-            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description,HelpLinkUri);
+            Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description,_HelpLinkUri);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_Rule);
 

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/AsyncVoid.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/AsyncVoid.cs
@@ -4,15 +4,15 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace IntelliTectAnalyzer.CodeFixes
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncVoid)), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncVoid))]
+    [Shared]
     public class AsyncVoid : CodeFixProvider
     {
         private const string Title = "Fix Design Violation: Follow AsyncVoid";

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/AttributesOnSeparateLines.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/AttributesOnSeparateLines.cs
@@ -14,7 +14,8 @@ using Microsoft.CodeAnalysis.Formatting;
 
 namespace IntelliTectAnalyzer.CodeFixes
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AttributesOnSeparateLines)), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AttributesOnSeparateLines))]
+    [Shared]
     public class AttributesOnSeparateLines : CodeFixProvider
     {
         private const string Title = "Fix Format Violation: Put Attributes on separate Lines";

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingFieldPascalUnderscore.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingFieldPascalUnderscore.cs
@@ -1,22 +1,19 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Text;
-using IntelliTectAnalyzer.Analyzers;
 
 namespace IntelliTectAnalyzer.CodeFixes
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingFieldPascalUnderscore)), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingFieldPascalUnderscore))]
+    [Shared]
     public class NamingFieldPascalUnderscore : CodeFixProvider
     {
         private const string Title = "Fix Naming Violation: Follow _PascalCase";

--- a/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingIdentifierPascal.cs
+++ b/IntelliTectAnalyzer/IntelliTectAnalyzer/CodeFixes/NamingIdentifierPascal.cs
@@ -1,22 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Text;
-using IntelliTectAnalyzer.Analyzers;
 
 namespace IntelliTectAnalyzer.CodeFixes
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingIdentifierPascal)), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(NamingIdentifierPascal))]
+    [Shared]
     public class NamingIdentifierPascal : CodeFixProvider
     {
         private const string Title = "Fix Naming Violation: Follow PascalCase";

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ steps:
   displayName: 'Test'
   inputs:
     command: 'test'
-    projects: '**/IntelliTectAnalyzer.Tests.csproj'
+    projects: '**/*.Tests.csproj'
 
 - task: PowerShell@2
   displayName: 'dotnet pack'


### PR DESCRIPTION
Fixed all of the detected errors.

This caught the bug where INTL0001 was flagging auto property getters and setters.