### PR TITLE
Ensuring only valid PascalCharacters

### DIFF
--- a/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/IntelliTect.Analyzer.Tests.csproj
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/IntelliTect.Analyzer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>CA2007,CA1815,CA1303,CA1707,CA1305</NoWarn>
   </PropertyGroup>
 

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingFieldPascalUnderscoreTests.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingFieldPascalUnderscoreTests.cs
@@ -55,7 +55,6 @@ namespace IntelliTect.Analyzer.Tests
             VerifyCSharpDiagnostic(test);
         }
 
-
         [TestMethod]
         public void FieldWithNamingViolation_FieldMissingLeadingUnderscore_Warning()
         {
@@ -417,6 +416,41 @@ namespace IntelliTect.Analyzer.Tests
 
             VerifyCSharpDiagnostic(test);
         }
+
+
+        [TestMethod]
+        [Description("Issue 80")]
+        public void FieldWithNamingViolation_FieldContainsUnderscore_Warning()
+        {
+            string test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {   
+            public string _My_Field;
+        }
+    }";
+            var expected = new DiagnosticResult
+            {
+                Id = "INTL0001",
+                Message = "Field '_My_Field' should be named _PascalCase",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 13, 27)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingMethodPascalTests.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingMethodPascalTests.cs
@@ -322,6 +322,45 @@ namespace AspNetCore
             VerifyCSharpDiagnostic(test);
         }
 
+
+        [TestMethod]
+        [Description("Issue 80")]
+        public void MethodWithNamingViolation_MethodWithUnderscore_Warning()
+        {
+            string test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {   
+            public string My_Method() 
+            {
+                return string.Empty;
+            } 
+        }
+    }";
+            var expected = new DiagnosticResult
+            {
+                Id = "INTL0003",
+                Message = "Method 'My_Method' should be PascalCase",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 13, 27)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new CodeFixes.NamingIdentifierPascal();

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingPropertyPascalTests.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/NamingPropertyPascalTests.cs
@@ -265,6 +265,40 @@ namespace AspNetCore
             VerifyCSharpDiagnostic(test);
         }
 
+        [TestMethod]
+        [Description("Issue 80")]
+        public void PropertyWithNamingViolation_PropertyContainsUnderscore_Warning()
+        {
+            string test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+        class TypeName
+        {   
+            public string My_Property { get; set; }
+        }
+    }";
+            var expected = new DiagnosticResult
+            {
+                Id = "INTL0002",
+                Message = "Property 'My_Property' should be PascalCase",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[] {
+                            new DiagnosticResultLocation("Test0.cs", 13, 27)
+                        }
+            };
+
+            VerifyCSharpDiagnostic(test, expected);
+        }
+
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new CodeFixes.NamingIdentifierPascal();

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingFieldPascalUnderscore.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingFieldPascalUnderscore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using IntelliTect.Analyzer.Naming;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -57,7 +58,7 @@ namespace IntelliTect.Analyzer.Analyzers
             }
 
             if (namedTypeSymbol.Name.StartsWith("_", StringComparison.Ordinal) && namedTypeSymbol.Name.Length > 1 
-                                                     && char.IsUpper(namedTypeSymbol.Name.Skip(1).First()))
+                                                     && Casing.IsPascalCase(namedTypeSymbol.Name.Skip(1)))
             {
                 return;
             }

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingMethodPascal.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingMethodPascal.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using IntelliTect.Analyzer.Naming;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -66,7 +67,7 @@ namespace IntelliTect.Analyzer.Analyzers
                 return;
             }
 
-            if (char.IsUpper(namedTypeSymbol.Name.First()))
+            if (Casing.IsPascalCase(namedTypeSymbol.Name))
             {
                 return;
             }

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingPropertyPascal.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/Analyzers/NamingPropertyPascal.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
+using IntelliTect.Analyzer.Naming;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -44,17 +45,17 @@ namespace IntelliTect.Analyzer.Analyzers
                 return;
             }
 
-            if (char.IsUpper(namedTypeSymbol.Name.First()))
-            {
-                return;
-            }
-
             if (namedTypeSymbol.ContainingType.IsNativeMethodsClass())
             {
                 return;
             }
 
             if (namedTypeSymbol is IPropertySymbol property && property.IsIndexer)
+            {
+                return;
+            }
+
+            if (Casing.IsPascalCase(namedTypeSymbol.Name))
             {
                 return;
             }

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/Naming/Casing.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/Naming/Casing.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace IntelliTect.Analyzer.Naming
+{
+    internal static class Casing
+    {
+        public static bool IsPascalCase(IEnumerable<char> name)
+        {
+            bool isFirst = true;
+            foreach (char character in name)
+            {
+                if (isFirst && !char.IsUpper(character))
+                {
+                    return false;
+                }
+
+                isFirst = false;
+                if (char.IsUpper(character) ||
+                    char.IsLower(character) ||
+                    char.IsNumber(character))
+                {
+                    continue;
+                }
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ pool:
 
 steps:
 
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+
 - task: NuGetToolInstaller@0
   displayName: 'Use latest NuGet'
 


### PR DESCRIPTION
Fixes #80

Questions: Is it acceptable to only allow upper/lower/number for naming on methods/properties/fields? Any counter examples?