### PR TITLE
ci: migrate NuGet publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -50,6 +50,9 @@ jobs:
       name: "Production"
       url: "https://www.nuget.org/packages/IntelliTect.Analyzers"
     name: Push NuGets
+    permissions:
+      id-token: write  # Required for NuGet trusted publishing (OIDC)
+      contents: read
 
     steps:
       - name: Download artifact from build job
@@ -57,9 +60,15 @@ jobs:
         with:
           name: NuGet
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}  # nuget.org profile name (NOT email)
+
       - name: Push NuGet
         run: |
           $tagVersion = "${{ github.ref }}".substring(11)
           echo "TAG_VERSION=$tagVersion" >> $env:GITHUB_OUTPUT
-          dotnet nuget push IntelliTect.Analyzers.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+          dotnet nuget push IntelliTect.Analyzers.$tagVersion.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --skip-duplicate
         id: tag-version

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       id-token: write  # Required for NuGet trusted publishing (OIDC)
       contents: read
+      actions: read    # Required for actions/download-artifact
 
     steps:
       - name: Download artifact from build job


### PR DESCRIPTION
## Summary

Migrates the NuGet publish step in `Deploy.yml` from a long-lived `NUGET_API_KEY` secret to OIDC-based trusted publishing via `NuGet/login@v1`.

## Changes

- Added `permissions: id-token: write` to the `deploy` job (required for OIDC token issuance)
- Added `NuGet/login@v1` step to exchange the OIDC token for a short-lived NuGet API key
- Replaced `secrets.NUGET_API_KEY` with `steps.login.outputs.NUGET_API_KEY` in the push step

## nuget.org Setup (already done)

A trusted publishing policy has been created on nuget.org for `IntelliTect.Analyzers`:
- **Owner**: IntelliTect
- **Repository**: CodingGuidelines
- **Workflow**: `Deploy.yml`
- **Environment**: `Production`

## Required Action Before Merging

Add a `NUGET_USER` secret to the **Production** GitHub environment:
- **Name**: `NUGET_USER`
- **Value**: the nuget.org profile name (not email) of the `IntelliTect-Nuget` account

## After First Successful Publish

Once a release triggers a successful publish via OIDC, the old `NUGET_API_KEY` secret can be removed from the repository secrets.