### PR TITLE
analyzer: add MIT PackageLicenseExpression to NuGet package

### DIFF
--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/IntelliTect.Analyzer.csproj
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/IntelliTect.Analyzer.csproj
@@ -9,6 +9,7 @@
     <PackageId>IntelliTect.Analyzers</PackageId>
     <Authors>IntelliTect</Authors>
     <RepositoryUrl>https://github.com/IntelliTect/CodingGuidelines</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Analyzer aiding the implementation of IntelliTect internal coding guidelines</Description>
     <Copyright>Copyright 2021</Copyright>


### PR DESCRIPTION
## Summary

Fixes the NuGet authoring best-practices warning:

> warn : License missing. See how to include a license within the package: https://aka.ms/nuget/authoring-best-practices#licensing.

## Change

Added `<PackageLicenseExpression>MIT</PackageLicenseExpression>` to `IntelliTect.Analyzer/IntelliTect.Analyzer/IntelliTect.Analyzer.csproj`.

This uses the recommended SPDX expression approach and matches the existing `LICENSE` (MIT) file already present in the repository.

## Reviewers

- Only one line added to the `.csproj`; no logic changes.